### PR TITLE
Update Android SDK and minimal supported versions

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,18 +1,6 @@
 group 'com.superwall.superwallkit_flutter'
 version '1.0-SNAPSHOT'
 
-buildscript {
-    ext.kotlin_version = '1.7.10'
-    repositories {
-        google()
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.0'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
 
 allprojects {
     repositories {
@@ -81,11 +69,11 @@ android {
         buildConfigField "boolean", "WAIT_FOR_DEBUGGER", waitForDebugger
     }
 }
-
+android.buildFeatures.buildConfig true
 dependencies {
     testImplementation 'org.jetbrains.kotlin:kotlin-test'
     testImplementation 'org.mockito:mockito-core:5.0.0'
 
-    implementation "com.superwall.sdk:superwall-android:1.1.7"
+    implementation "com.superwall.sdk:superwall-android:1.1.8"
     implementation 'com.android.billingclient:billing:6.1.0'
 }

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,1 +1,5 @@
+plugins {
+    id "com.android.application" version "8.1.0" apply false
+    id "org.jetbrains.kotlin.android" version "1.8.0" apply false
+}
 rootProject.name = 'superwallkit_flutter'

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,15 +1,3 @@
-buildscript {
-    ext.kotlin_version = '1.7.10'
-    repositories {
-        google()
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
-
 rootProject.buildDir = '../build'
 subprojects {
     project.buildDir = "${rootProject.buildDir}/${project.name}"

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-all.zip

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -23,7 +23,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "7.3.0" apply false
+    id "com.android.application" version "8.1.0" apply false
+    id "org.jetbrains.kotlin.android" version "1.8.0" apply false
 }
 
 include ":app", ':superwallkit_flutter'


### PR DESCRIPTION
### Enhancements - BREAKING
- Upgrades Android SDK to 1.1.8. [View Android SDK release notes](https://github.com/superwall-me/Superwall-Android/releases/tag/1.1.7)
- Requires minimal Kotlin version `1.8.0` and minimal Android Gradle Plugin version `8.1.0`.
