### PR TITLE
Remove `set it` print statement

### DIFF
--- a/lib/src/public/Superwall.dart
+++ b/lib/src/public/Superwall.dart
@@ -166,7 +166,6 @@ class Superwall extends BridgeIdInstantiable {
     var result = await bridgeId.communicator.invokeBridgeMethod(
         'setSubscriptionStatus',
         {'subscriptionStatusBridgeId': subscriptionStatusBridgeId});
-    print("set it");
   }
 
   // Asynchronous method to check if Superwall has finished configuring


### PR DESCRIPTION
This `set it` print statement gets triggered several times in my app's startup init sequence—just sharing my suppression commit for convenience / reminder to remove it in the next release if possible (at least until `loggy` or similar is implemented).

<img width="1012" alt="Screenshot 2024-06-24 at 2 48 24 PM" src="https://github.com/superwall/Superwall-Flutter/assets/1598289/5b673312-26b1-4a8b-9513-f5320dcee2ba">
