### PR TITLE
Ensure bridgeId's remain static, allow for rebinding of flutter plugin

### DIFF
--- a/android/src/main/kotlin/com/superwall/superwallkit_flutter/BridgingCreator.kt
+++ b/android/src/main/kotlin/com/superwall/superwallkit_flutter/BridgingCreator.kt
@@ -11,6 +11,7 @@ import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
 import java.util.concurrent.ConcurrentHashMap
+import io.flutter.embedding.android.FlutterActivity
 
 class BridgingCreator(val flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) : MethodCallHandler {
     private val instances: MutableMap<String, BridgeInstance> = ConcurrentHashMap()
@@ -26,25 +27,15 @@ class BridgingCreator(val flutterPluginBinding: FlutterPlugin.FlutterPluginBindi
         var flutterPluginBinding: FlutterPlugin.FlutterPluginBinding?
             get() = _flutterPluginBinding
             set(value) {
-                // Only allow binding to occur once. It appears that if binding is set multiple
-                // times (due to other SDK interference), we'll lose access to the
-                // SuperwallKitFlutterPlugin current activity
-                if (_flutterPluginBinding != null) {
-                    println("WARNING: Attempting to set a flutter plugin binding again.")
-                    return
-                }
-
                 // Store for getter
                 _flutterPluginBinding = value
 
                 _flutterPluginBinding?.let {
                     synchronized(BridgingCreator::class.java) {
-                        if (_shared == null) {
                             val bridge = BridgingCreator(it)
                             _shared = bridge
                             val communicator = Communicator(it.binaryMessenger, "SWK_BridgingCreator")
                             communicator.setMethodCallHandler(bridge)
-                        }
                     }
                 }
             }

--- a/android/src/main/kotlin/com/superwall/superwallkit_flutter/SuperwallkitFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/superwall/superwallkit_flutter/SuperwallkitFlutterPlugin.kt
@@ -14,130 +14,132 @@ import java.util.WeakHashMap
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 
-class SuperwallkitFlutterPlugin: FlutterPlugin, ActivityAware {
-  var currentActivity: Activity? = null
+class SuperwallkitFlutterPlugin : FlutterPlugin, ActivityAware {
+    var currentActivity: Activity? = null
 
-  companion object {
-    private var instance: SuperwallkitFlutterPlugin? = null
+    companion object {
+        private var instance: SuperwallkitFlutterPlugin? = null
 
-    val currentActivity: Activity?
-      get() = instance?.currentActivity
-  }
-
-  init {
-    if (BuildConfig.DEBUG && BuildConfig.WAIT_FOR_DEBUGGER) {
-      Debug.waitForDebugger()
+        val currentActivity: Activity?
+            get() = instance?.currentActivity
     }
 
-    // Only allow instance to get set once.
-    if (instance == null) {
-      instance = this
+    init {
+        if (BuildConfig.DEBUG && BuildConfig.WAIT_FOR_DEBUGGER) {
+            Debug.waitForDebugger()
+        }
+
+        // Only allow instance to get set once.
+        if (instance == null) {
+            instance = this
+        }
     }
-  }
 
-  override fun onAttachedToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
-    BridgingCreator.flutterPluginBinding = flutterPluginBinding
-  }
+    override fun onAttachedToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
+        BridgingCreator.flutterPluginBinding = flutterPluginBinding
+    }
 
-  override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
-    BridgingCreator.shared.tearDown()
-    instance = null
-  }
+    override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+        BridgingCreator.shared.tearDown()
+        instance = null
+    }
 
-  //region ActivityAware
+    //region ActivityAware
 
-  override fun onAttachedToActivity(binding: ActivityPluginBinding) {
-    currentActivity = binding.activity
-  }
+    override fun onAttachedToActivity(binding: ActivityPluginBinding) {
+        currentActivity = binding.activity
+    }
 
-  override fun onDetachedFromActivityForConfigChanges() {
-    currentActivity = null
-  }
+    override fun onDetachedFromActivityForConfigChanges() {
+        currentActivity = null
+    }
 
-  override fun onReattachedToActivityForConfigChanges(binding: ActivityPluginBinding) {
-    currentActivity = binding.activity
-  }
+    override fun onReattachedToActivityForConfigChanges(binding: ActivityPluginBinding) {
+        currentActivity = binding.activity
+    }
 
-  override fun onDetachedFromActivity() {
-    currentActivity = null
-  }
+    override fun onDetachedFromActivity() {
+        currentActivity = null
+    }
 
-  //endregion
+    //endregion
 }
 
 fun <T> MethodCall.argumentForKey(key: String): T? {
-  return this.argument(key)
+    return this.argument(key)
 }
 
 // Make sure to provide the key for the bridge (which provides the bridgeId)
 fun <T> MethodCall.bridgeInstance(key: String): T? {
-  BreadCrumbs.append("SuperwallKitFlutterPlugin.kt: Invoke bridgeInstance(key:) on $this. Key is $key")
-  val bridgeId = this.argument<String>(key) ?: return null
-  BreadCrumbs.append("SuperwallKitFlutterPlugin.kt: Invoke bridgeInstance(key:) in on $this. Found bridgeId $bridgeId")
-  return BridgingCreator.shared.bridgeInstance(bridgeId)
+    BreadCrumbs.append("SuperwallKitFlutterPlugin.kt: Invoke bridgeInstance(key:) on $this. Key is $key")
+    val bridgeId = this.argument<String>(key) ?: return null
+    BreadCrumbs.append("SuperwallKitFlutterPlugin.kt: Invoke bridgeInstance(key:) in on $this. Found bridgeId $bridgeId")
+    return BridgingCreator.shared.bridgeInstance(bridgeId)
 }
 
 fun <T> BridgeId.bridgeInstance(): T? {
-  BreadCrumbs.append("SuperwallKitFlutterPlugin.kt: Invoke bridgeInstance() in on $this")
-  return BridgingCreator.shared.bridgeInstance(this)
+    BreadCrumbs.append("SuperwallKitFlutterPlugin.kt: Invoke bridgeInstance() in on $this")
+    return BridgingCreator.shared.bridgeInstance(this)
 }
 
 fun MethodChannel.Result.badArgs(call: MethodCall) {
-  return badArgs(call.method)
+    return badArgs(call.method)
 }
 
 fun MethodChannel.Result.badArgs(method: String) {
-  return error("BAD_ARGS", "Missing or invalid arguments for '$method'", null)
+    return error("BAD_ARGS", "Missing or invalid arguments for '$method'", null)
 }
 
 fun MethodChannel.invokeMethodOnMain(method: String, arguments: Any? = null) {
-  runOnUiThread {
-    invokeMethod(method, arguments);
-  }
+    runOnUiThread {
+        invokeMethod(method, arguments);
+    }
 }
 
-suspend fun MethodChannel.asyncInvokeMethodOnMain(method: String, arguments: Any? = null): Any? = suspendCancellableCoroutine { continuation ->
-  runOnUiThread {
-    invokeMethod(method, arguments, object : MethodChannel.Result {
-      override fun success(result: Any?) {
-        continuation.resume(result)
-      }
+suspend fun MethodChannel.asyncInvokeMethodOnMain(method: String, arguments: Any? = null): Any? =
+    suspendCancellableCoroutine { continuation ->
+        runOnUiThread {
+            invokeMethod(method, arguments, object : MethodChannel.Result {
+                override fun success(result: Any?) {
+                    continuation.resume(result)
+                }
 
-      override fun error(errorCode: String, errorMessage: String?, errorDetails: Any?) {
-        continuation.resumeWithException(
-          RuntimeException("Error invoking method: $errorCode, $errorMessage")
-        )
-      }
+                override fun error(errorCode: String, errorMessage: String?, errorDetails: Any?) {
+                    continuation.resumeWithException(
+                        RuntimeException("Error invoking method: $errorCode, $errorMessage")
+                    )
+                }
 
-      override fun notImplemented() {
-        continuation.resumeWithException(
-          UnsupportedOperationException("Method not implemented: $method")
-        )
-      }
-    })
-  }
-}
+                override fun notImplemented() {
+                    continuation.resumeWithException(
+                        UnsupportedOperationException("Method not implemented: $method")
+                    )
+                }
+            })
+        }
+    }
 
 fun <T> Map<String, Any?>.argument(key: String): T? {
-  return this[key] as? T
+    return this[key] as? T
 }
 
 object MethodChannelAssociations {
-  private val bridgeIds = WeakHashMap<MethodChannel, String>()
+    private val bridgeIds = WeakHashMap<MethodChannel, String>()
 
-  fun setBridgeId(methodChannel: MethodChannel, bridgeId: String) {
-    bridgeIds[methodChannel] = bridgeId
-  }
+    fun setBridgeId(methodChannel: MethodChannel, bridgeId: String) {
+        bridgeIds[methodChannel] = bridgeId
+    }
 
-  fun getBridgeId(methodChannel: MethodChannel): String {
-    return bridgeIds[methodChannel] ?: throw IllegalStateException("bridgeId must be set at initialization of MethodChannel")
-  }
+    fun getBridgeId(methodChannel: MethodChannel): String {
+        return bridgeIds[methodChannel]
+            ?: throw IllegalStateException("bridgeId must be set at initialization of MethodChannel")
+    }
 }
 
 fun MethodChannel.setBridgeId(bridgeId: String) {
-  MethodChannelAssociations.setBridgeId(this, bridgeId)
+    MethodChannelAssociations.setBridgeId(this, bridgeId)
 }
 
 fun MethodChannel.getBridgeId(): String {
-  return MethodChannelAssociations.getBridgeId(this)
+    return MethodChannelAssociations.getBridgeId(this)
 }

--- a/android/src/main/kotlin/com/superwall/superwallkit_flutter/bridges/BridgeInstance.kt
+++ b/android/src/main/kotlin/com/superwall/superwallkit_flutter/bridges/BridgeInstance.kt
@@ -38,5 +38,5 @@ fun BridgeId.bridgeClass(): BridgeClass {
 }
 
 fun BridgeClass.generateBridgeId(): BridgeId {
-    return "$this-${UUID.randomUUID()}-bridgeId"
+    return "$this-bridgeId"
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -134,26 +134,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.0"
+    version: "10.0.4"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.3"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -182,10 +182,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.12.0"
   path:
     dependency: transitive
     description:
@@ -277,7 +277,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.1.8"
+    version: "1.1.9"
   sync_http:
     dependency: transitive
     description:
@@ -298,10 +298,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.0"
   typed_data:
     dependency: transitive
     description:
@@ -330,10 +330,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "14.2.1"
   webdriver:
     dependency: transitive
     description:
@@ -343,5 +343,5 @@ packages:
     source: hosted
     version: "3.0.3"
 sdks:
-  dart: ">=3.2.0 <4.0.0"
-  flutter: ">=3.3.0"
+  dart: ">=3.3.0 <4.0.0"
+  flutter: ">=3.18.0-18.0.pre.54"

--- a/ios/Classes/Bridges/BridgeInstance.swift
+++ b/ios/Classes/Bridges/BridgeInstance.swift
@@ -42,7 +42,7 @@ extension BridgeId {
 extension BridgeClass {
   // Make sure this is the same on the Dart side.
   func generateBridgeId() -> BridgeId {
-    return "\(self)-\(UUID().uuidString)-bridgeId"
+    return "\(self)-bridgeId"
   }
 }
 

--- a/lib/src/private/BridgingCreator.dart
+++ b/lib/src/private/BridgingCreator.dart
@@ -147,8 +147,7 @@ extension StringExtension on String {
 extension Additions on BridgeClass {
   // Make sure this is the same on the Native side.
   BridgeId generateBridgeId() {
-    final instanceIdentifier = const Uuid().v4();
-    final bridgeId = "$this-$instanceIdentifier-bridgeId";
+    final bridgeId = "$this-bridgeId";
     return bridgeId;
   }
 }


### PR DESCRIPTION
### Changes

- Allows rebinding of the plugin - If the original `FlutterActivity` dies in the background or gets recreated, our `BridgingCreator` doesn't reattach properly to it since we block binding from happening more than once. This causes all bridge instances to be invalid, since we expect them to exist but the binding itself doesn't exist anymore. 
- Changes `bridgeId`'s to be static instead of containing UUId's, since otherwise the bridge can get recreated during restart/reload and lose the connection due to mismatched identifiers.