### PR TITLE
1.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 The changelog for `Superwall`. Also see the [releases](https://github.com/superwall/Superwall-Flutter/releases) on GitHub.
 
+## 1.3.3
+- Upgrades Android SDK to 1.3.1 [View Android SDK release notes](https://github.com/superwall-me/Superwall-Android/releases/tag/1.3.1)
+  - This fixes the issue when using Superwall with some SDK's would cause a crash (i.e. Smartlook SDK)
+
 
 ## 1.3.2
 
@@ -12,7 +16,7 @@ The changelog for `Superwall`. Also see the [releases](https://github.com/superw
 ## 1.3.1
 
 ### Enhancements
-- Upgrades Android SDK to 1.3.0 [View Android SDK release notes](https://github.com/superwall-me/Superwall-Android/releases/tag/1.3.1)
+- Upgrades Android SDK to 1.3.0 [View Android SDK release notes](https://github.com/superwall-me/Superwall-Android/releases/tag/1.3.0)
 - Upgrades Android SDK to 3.10.1 [View Android SDK release notes](https://github.com/superwall-me/Superwall-iOS/releases/tag/3.10.1)
 - Adds `confirmAllAssignments` method to `Superwall` which confirms assignments for all placements and returns an array of all confirmed experiment assignments. Note that the assignments may be different when a placement is registered due to changes in user, placement, or device parameters used in audience filters.
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -74,6 +74,6 @@ dependencies {
     testImplementation 'org.jetbrains.kotlin:kotlin-test'
     testImplementation 'org.mockito:mockito-core:5.0.0'
 
-    implementation "com.superwall.sdk:superwall-android:1.3.0"
+    implementation "com.superwall.sdk:superwall-android:1.3.1"
     implementation 'com.android.billingclient:billing:6.1.0'
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: superwallkit_flutter
 description: "Remotely configure every aspect of your paywall and double your revenue."
-version: 1.3.2
+version: 1.3.3
 homepage: "https://superwall.com"
 
 environment:


### PR DESCRIPTION
## 1.3.3
- Upgrades Android SDK to 1.3.1 [View Android SDK release notes](https://github.com/superwall-me/Superwall-Android/releases/tag/1.3.1)
  - This fixes the issue when using Superwall with some SDK's would cause a crash (i.e. Smartlook SDK)
